### PR TITLE
Style products buttons

### DIFF
--- a/src/Containers/MarketPage/MarketPage.js
+++ b/src/Containers/MarketPage/MarketPage.js
@@ -24,16 +24,18 @@ export const MarketPage = ({ history }) => {
 
   return (
     <section className='section-market-page-container'>
-      <h2 className='market-name'>{marketInfo.name}</h2>
-      <h3>Address: </h3>
-      <p>{marketInfo.address}</p>
-      <h3>Schedule: </h3>
-      <p className='market-schedule'>{marketInfo.schedule}</p>
-      <h3>Google Maps: </h3>
-      <a href={marketInfo.google_link}>Click Here For Directions</a>
-      <button className='find-vendors-button' onClick={ handleSubmit }>
-        Find Vendors
-      </button>
+      <div className='section-market-info-container'>
+        <h2 className='market-name'>{marketInfo.name}</h2>
+        <h3>Address: </h3>
+        <p>{marketInfo.address}</p>
+        <h3>Schedule: </h3>
+        <p className='market-schedule'>{marketInfo.schedule}</p>
+        <h3>Google Maps: </h3>
+        <a href={marketInfo.google_link}>Click Here For Directions</a>
+        </div>
+        <button className='find-vendors-button' onClick={ handleSubmit }>
+          Find Vendors
+        </button>
     </section>
   )
 }

--- a/src/Containers/MarketPage/MarketPage.scss
+++ b/src/Containers/MarketPage/MarketPage.scss
@@ -9,6 +9,15 @@
   background-color: white;
   border-right: 2px solid black;
   margin: auto;
+  text-align: center;
+}
+.section-market-info-container {
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  overflow: auto;
 }
 
 .market-name{
@@ -29,8 +38,8 @@
   margin-top: 30px;
   outline: 0;
   width: 50%;
-  background-color:cadetblue;
-  cursor: pointer;
+  background-color: #5E7838;
+  color: #FAF6F5;
 }
 .find-vendors-button:hover,
 .find-vendors-button:focus {

--- a/src/Containers/MarketPage/__snapshots__/MarketPage.test.js.snap
+++ b/src/Containers/MarketPage/__snapshots__/MarketPage.test.js.snap
@@ -4,33 +4,37 @@ exports[`MarketPage should match the snapshot 1`] = `
 <section
   className="section-market-page-container"
 >
-  <h2
-    className="market-name"
+  <div
+    className="section-market-info-container"
   >
-    Friendly Famrs
-  </h2>
-  <h3>
-    Address: 
-  </h3>
-  <p>
-    1234 Hillsbury Lane
-  </p>
-  <h3>
-    Schedule: 
-  </h3>
-  <p
-    className="market-schedule"
-  >
-    M-F ALL DAY
-  </p>
-  <h3>
-    Google Maps: 
-  </h3>
-  <a
-    href="google.com"
-  >
-    Click Here For Directions
-  </a>
+    <h2
+      className="market-name"
+    >
+      Friendly Famrs
+    </h2>
+    <h3>
+      Address: 
+    </h3>
+    <p>
+      1234 Hillsbury Lane
+    </p>
+    <h3>
+      Schedule: 
+    </h3>
+    <p
+      className="market-schedule"
+    >
+      M-F ALL DAY
+    </p>
+    <h3>
+      Google Maps: 
+    </h3>
+    <a
+      href="google.com"
+    >
+      Click Here For Directions
+    </a>
+  </div>
   <button
     className="find-vendors-button"
     onClick={[Function]}

--- a/src/Containers/VendorPage/VendorPage.js
+++ b/src/Containers/VendorPage/VendorPage.js
@@ -23,14 +23,17 @@ export const VendorPage = ({ history }) => {
 
   return (
     <section className='section-vendor-page-container'>
-      <button className='vendor-page-button' onClick={handleBackToMarket}>Back to Vendors Page</button>
-      <div>
-        <h2 className='vendor-page-vendor-name'>{selectedVendor.name}</h2>
-        <h3>Description: </h3>
-          <p>{selectedVendor.description}</p>
-        <img className='vendor-img-vendor-page' src={selectedVendor.image_link}></img>
-          <h3>Products: </h3>
-            {products}
+      <div className='vendor-info-page-button-div'>
+        <button className='vendor-page-button' onClick={handleBackToMarket}>Back to Vendors</button>
+      </div>
+      <div className='vendor-info-page-div'>
+      <h2 className='vendor-page-vendor-name'>{selectedVendor.name}</h2>
+      <p>{selectedVendor.description}</p>
+      <img className='vendor-img-vendor-page' src={selectedVendor.image_link}></img>
+      </div>
+      <div className='vendor-info-page-products-div'>
+        <h3>Products: </h3>
+          {products}
       </div>
     </section>
   )

--- a/src/Containers/VendorPage/VendorPage.scss
+++ b/src/Containers/VendorPage/VendorPage.scss
@@ -23,11 +23,13 @@
 .vendor-info-page-div {
   width: 45%;
   overflow: auto;
+  height: 80%;
 }
 
 .vendor-info-page-products-div {
   width: 45%;
   overflow: auto;
+  height: 80%;
 }
 
 .vendor-img-vendor-page{

--- a/src/Containers/VendorPage/VendorPage.scss
+++ b/src/Containers/VendorPage/VendorPage.scss
@@ -1,4 +1,4 @@
-.section-vendor-page-container{
+.section-vendor-page-container {
     margin: auto;
     width: 75%;
     height: 80%;
@@ -51,8 +51,9 @@
     background-color: white;
 }
 
-.vendor-page-button{
+.vendor-page-button {
     width: 15%;
+    min-width: 155px;
     margin-top: 5px;
     text-align: center;
     cursor: pointer;

--- a/src/Containers/VendorPage/VendorPage.scss
+++ b/src/Containers/VendorPage/VendorPage.scss
@@ -1,15 +1,33 @@
 .section-vendor-page-container{
     margin: auto;
     width: 75%;
-    height: 75%;
+    height: 80%;
     display: flex;
-    flex-direction: column;
     align-items: center;
+    justify-content: space-around;
     overflow: auto;
     border: 3px solid #3B3D39;
     border-radius: 10px;
     background-color: #F2F9F9;
     border-right: 2px solid black;
+    text-align: center;
+    flex-wrap: wrap;
+}
+
+.vendor-info-page-button-div {
+  width: 90%;
+  display: flex;
+  align-items: flex-start;
+}
+
+.vendor-info-page-div {
+  width: 45%;
+  overflow: auto;
+}
+
+.vendor-info-page-products-div {
+  width: 45%;
+  overflow: auto;
 }
 
 .vendor-img-vendor-page{
@@ -20,19 +38,27 @@
 
 .vendor-page-vendor-name{
     text-align: center;
+    text-decoration: underline;
 }
 
 .product-article{
     margin: auto;
+    border: 3px solid #5E7838;
+    border-radius: 10px;
+    margin: 10px 0;
+    background-color: white;
 }
 
 .vendor-page-button{
-    width: 29%;
+    width: 15%;
     margin-top: 5px;
     text-align: center;
     cursor: pointer;
     line-height: 2px;
-    font-size: 12px;
+    font-size: 1em;
+    padding: 10px;
+    border: 2px solid #5E7838;
+    border-radius: 10px;
 }
 
 .vendor-page-button:hover,

--- a/src/Containers/VendorPage/__snapshots__/VendorPage.test.js.snap
+++ b/src/Containers/VendorPage/__snapshots__/VendorPage.test.js.snap
@@ -4,21 +4,24 @@ exports[`VendorPage should match the snapshot 1`] = `
 <section
   className="section-vendor-page-container"
 >
-  <button
-    className="vendor-page-button"
-    onClick={[Function]}
+  <div
+    className="vendor-info-page-button-div"
   >
-    Back to Vendors Page
-  </button>
-  <div>
+    <button
+      className="vendor-page-button"
+      onClick={[Function]}
+    >
+      Back to Vendors
+    </button>
+  </div>
+  <div
+    className="vendor-info-page-div"
+  >
     <h2
       className="vendor-page-vendor-name"
     >
       Rolling in the dough
     </h2>
-    <h3>
-      Description: 
-    </h3>
     <p>
       just a little bakery rolling in some dough
     </p>
@@ -26,6 +29,10 @@ exports[`VendorPage should match the snapshot 1`] = `
       className="vendor-img-vendor-page"
       src="rollthatdough.png"
     />
+  </div>
+  <div
+    className="vendor-info-page-products-div"
+  >
     <h3>
       Products: 
     </h3>

--- a/src/Containers/VendorSelectContainer/VendorSelectContainer.scss
+++ b/src/Containers/VendorSelectContainer/VendorSelectContainer.scss
@@ -13,7 +13,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  width: 60%;
+  width: 65%;
   min-width: 350px;
   background-color: white;
   border: 3px solid #3B3D39;
@@ -101,16 +101,16 @@
 }
 
 .link-create-vendor-form {
-  width: 25%;
-  height: 250px;
+  width: 15%;
+  height: 175px;
   text-decoration: none;
 }
 
 .create-vendor-button {
-  width: 55%;
-  height: 55%;
-  border-radius: 75px;
-  font-size: .8em;
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
+  font-size: 1.7em;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/Containers/VendorsContainer/VendorsContainer.scss
+++ b/src/Containers/VendorsContainer/VendorsContainer.scss
@@ -8,7 +8,7 @@
   align-items: center;
   text-align: center;
   overflow: scroll;
-  margin: 0;
-  padding: 0;
+  margin-top: 0;
+  padding-top: 20px;
   justify-content: space-evenly;
-  }
+}


### PR DESCRIPTION
### What does this PR do?
- This PR updates the create vendor button back to being a square and making it larger - fixes width issue as well
- Styles See Vendors button to be green to match rest of color
- Adds padding-top to vendorsContainer so that when hovered the vendor cards are not being cut-off
- reformats VendorPage to have information side-by-side and updates button to style to match app.
- puts products in styled cards to differentiate between the different products

### How to test?
 - pull down (clone down) and run npm install and npm start
 - run npm test to see passing tests
 -navigate to vendor login and update a vendor and products!

<img width="1398" alt="Screen Shot 2020-02-27 at 7 59 06 AM" src="https://user-images.githubusercontent.com/49846853/75456386-b0a68d80-5937-11ea-80eb-480a9146c99e.png">

<img width="1398" alt="Screen Shot 2020-02-27 at 7 59 13 AM" src="https://user-images.githubusercontent.com/49846853/75456397-b3a17e00-5937-11ea-8011-d7dad4f63724.png">

<img width="1398" alt="Screen Shot 2020-02-27 at 7 59 24 AM" src="https://user-images.githubusercontent.com/49846853/75456405-b603d800-5937-11ea-80c3-db4f4844b621.png">
